### PR TITLE
Fix style interpolation bug

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -21,7 +21,7 @@ const { overlay } = Astro.props;
 const overlayStyles = overlay ? 'margin-block-start: -4rem;' : '';
 ---
 
-<article class="section spot-color-gray-dark" style=`${overlayStyles}`>
+<article class="section spot-color-gray-dark" style={overlayStyles}>
   <svg
     aria-hidden="true"
     class="slant"


### PR DESCRIPTION
## Summary
- fix template literal on footer style attribute

## Testing
- `npm run lint` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b171a9d08330955395ba868533c4