### PR TITLE
Remove ReCaptcha

### DIFF
--- a/astro/src/components/FormBuilder.astro
+++ b/astro/src/components/FormBuilder.astro
@@ -126,7 +126,6 @@ const submitLabel =
   </aside>
   <form
     name="main"
-    data-netlify-recaptcha="true"
     netlify-honeypot="bot-field"
     class="switcher region wrapper"
     style=" --region-space-top: 0; --gutter: 0;"
@@ -196,9 +195,6 @@ const submitLabel =
             required
             aria-required="true"></textarea>
         </span>
-        <div class="stack">
-          <div data-netlify-recaptcha="true"><!-- recaptcha --></div>
-        </div>
         <button type="submit">{submitLabel}</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove Netlify ReCaptcha attribute and markup from the form builder

## Testing
- `npm run lint` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5f75dcb083308ebc1cd50308593c