### PR TITLE
Update README with deployment and Sanity commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This repository contains the source code for the Loumarc Signs website. The proj
 
 ## Project Structure
 
+The repository is divided into two top-level folders:
+
+- **`astro/`** – The Astro website
+- **`studio/`** – The Sanity Studio
+
 ```
 /
 ├── astro/   # Astro website
@@ -59,6 +64,17 @@ cd studio
 npm run dev
 ```
 
+## Sanity Studio Commands
+Run these commands from the `studio` directory:
+
+```bash
+npm run dev            # Start the Studio in development mode
+npm run start          # Serve the production build
+npm run build          # Build the Studio for production
+npm run deploy         # Deploy the Studio to Sanity
+npm run deploy-graphql # Deploy the GraphQL API
+```
+
 ## Building for Production
 To create a production build of the site and Studio:
 
@@ -71,6 +87,13 @@ npm run build
 cd ../studio
 npm run build
 ```
+
+## Deployment
+
+The site is automatically deployed to [Netlify](https://www.netlify.com/). The
+`netlify.toml` file configures the build to run inside the `astro` directory.
+Pushing to the `main` branch triggers a new deployment. The current status of
+these deployments is shown by the Netlify badge at the top of this README.
 
 ## Resources
 - [Astro – Getting Started](https://docs.astro.build/en/getting-started/)


### PR DESCRIPTION
## Summary
- document `/astro` and `/studio` layout
- add Sanity Studio command reference
- explain Netlify deployment and keep status badge

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687b82aed8808330919c781815b75b3a