### PR TITLE
Add Sanity commands and Netlify info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ This repository contains the source code for the Loumarc Signs website. The proj
 │       ├── pages/
 │       ├── ts/
 │       └── utils/
-└── studio/  # Sanity Studio
-    ├── schemas/
-    └── src/
-        └── structure/
+├── studio/  # Sanity Studio
+│   ├── schemas/
+│   └── src/
+│       └── structure/
+└── netlify.toml  # Netlify configuration
 ```
 
 ## Installation
@@ -71,6 +72,25 @@ npm run build
 cd ../studio
 npm run build
 ```
+
+## Sanity Studio Commands
+
+Run these commands from the `/studio` directory to work with the Sanity Studio:
+
+| Command | Action |
+| :--------------------- | :--------------------------------------------- |
+| `npm run dev` | Start the Studio locally |
+| `npm run build` | Build the Studio for production |
+| `npm run start` | Serve the built Studio |
+| `npm run deploy` | Deploy the Studio to Sanity.io |
+| `npm run deploy-graphql` | Deploy the GraphQL API |
+
+## Deployment
+
+The Astro site is deployed through [Netlify](https://www.netlify.com/) using the
+configuration in `netlify.toml`. Updates to the `main` branch automatically
+trigger a new deploy. The status badge at the top of this README reflects the
+latest deployment state.
 
 ## Resources
 - [Astro – Getting Started](https://docs.astro.build/en/getting-started/)

--- a/studio/README.md
+++ b/studio/README.md
@@ -7,3 +7,13 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - [Join the community Slack](https://slack.sanity.io/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)
+
+## Commands
+
+Run these from the `/studio` directory:
+
+- `npm run dev` – Start the Studio locally
+- `npm run build` – Build the Studio for production
+- `npm run start` – Serve the built Studio
+- `npm run deploy` – Deploy the Studio to Sanity.io
+- `npm run deploy-graphql` – Deploy the GraphQL API


### PR DESCRIPTION
## Summary
- document /astro and /studio directories in project structure
- list Sanity studio commands in both README files
- add deployment section with Netlify details and keep status badge

## Testing
- `npm run build` in `astro`
- `npx sanity --version`

------
https://chatgpt.com/codex/tasks/task_e_687b82aed8808330919c781815b75b3a