### PR TITLE
[codex] Add structured form-spam monitoring logs

### DIFF
--- a/astro/README.md
+++ b/astro/README.md
@@ -26,7 +26,7 @@ Public form traffic is protected in two layers:
 - `/forms/*` is handled by `netlify/edge-functions/forms-gate.ts`, which exports a Netlify code-based rate limit of 6 POST requests per IP/domain per 60 seconds.
 - `/api/challenge`, `/api/redeem`, and `/api/validate` are routed to `netlify/functions/cap.js` through Netlify redirects, with per-IP/domain rate limits in `netlify.toml` before the function is invoked.
 
-Those code-based rules block with HTTP `429` before the handler runs in production. `forms-gate.ts` validates completed form submissions through `/.netlify/functions/cap/validate` so successful form submissions do not share the public `/api/validate` redirect bucket. The handlers also use `netlify/functions/_shared/rate-limit.js` as a local fallback and log allowed/blocked decisions with a source fingerprint, method, path, count, and reset time. Do not log form fields, message contents, tokens, or full IP addresses when tuning this code.
+Those code-based rules block with HTTP `429` before the handler runs in production. `forms-gate.ts` validates completed form submissions through `/.netlify/functions/cap/validate` so successful form submissions do not share the public `/api/validate` redirect bucket. The handlers also use `netlify/functions/_shared/rate-limit.js` as a local fallback and log allowed/blocked decisions through the shared form-spam monitoring event. Do not log form fields, message contents, tokens, or full IP addresses when tuning this code.
 
 When `LOUMARC_INTERNAL_RATE_LIMIT_SECRET` is configured, `forms-gate.ts` signs that internal validation request and forwards the original visitor source so fallback validation limits remain per visitor. Direct public requests to `/.netlify/functions/cap/validate` cannot spoof that source header without the secret.
 
@@ -38,6 +38,29 @@ When `LOUMARC_INTERNAL_RATE_LIMIT_SECRET` is configured, `forms-gate.ts` signs t
 Both entry types include expiration metadata and use strong-consistency conditional writes so replay checks work across serverless instances. Do not replace this with function memory, warm instance state, `/tmp`, or a full database without a follow-up architecture decision.
 
 To tune the limits, update the `RATE_LIMIT_POLICIES` constants in `netlify/functions/_shared/rate-limit.js`, the exported `config.rateLimit` value in the edge function, and the `[redirects.rate_limit]` values in `netlify.toml`. After deployment, check Netlify's deploy post-processing logs to confirm the code-based rate limit rules were detected.
+
+## Form-Spam Monitoring Logs
+
+Form-spam protection logs use one JSON event name: `loumarc.form_spam`. Each line includes `schemaVersion`, `surface`, `action`, `result`, `reason`, `method`, `path`, `status` when applicable, and a `sourceHash` instead of a raw IP address. Form field values, message contents, customer contact details, and CapJS tokens must not be added to this event.
+
+Common `forms-gate` reasons are `honeypot`, `missing-token`, `invalid-token`, `validation-error`, `forwarded`, and `upstream-forwarding`. Common `cap-verification` reasons are `challenge-created`, `redeem-success`, `redeem-failure`, `validate-success`, `validate-failure`, and `malformed-request`. Rate-limit decisions use the same event shape with `surface: "rate-limit"` and `reason: "rate-limit"` when blocked.
+
+Use the Netlify CLI to review recent activity:
+
+```bash
+# Recent form gate decisions
+npx netlify logs --since 1h --source edge-functions --edge-function forms-gate | grep 'loumarc.form_spam'
+
+# Recent CapJS challenge/redeem/validate decisions
+npx netlify logs --since 1h --source functions --function cap | grep 'loumarc.form_spam'
+
+# Count blocked versus forwarded form submissions in the last day
+npx netlify logs --since 24h --source edge-functions --edge-function forms-gate | grep 'loumarc.form_spam' | grep '"result":"blocked"' | wc -l
+npx netlify logs --since 24h --source edge-functions --edge-function forms-gate | grep 'loumarc.form_spam' | grep '"result":"forwarded"' | wc -l
+
+# Follow live form-spam protection decisions during deploy verification
+npx netlify logs --follow --source functions --source edge-functions | grep 'loumarc.form_spam'
+```
 
 ## Form Verification Checks
 

--- a/astro/netlify/edge-functions/forms-gate.ts
+++ b/astro/netlify/edge-functions/forms-gate.ts
@@ -85,24 +85,40 @@ import {
   logRateLimitDecision,
   RATE_LIMIT_POLICIES,
 } from '../functions/_shared/rate-limit.js'
+import { logFormSpamEvent } from '../functions/_shared/spam-monitoring.js'
 
 export default async (request: Request, context: any) => {
   try {
-    // Basic trace
     const { pathname } = new URL(request.url)
-    console.log(`[forms-gate] start ${request.method} ${pathname}`)
+    const requestSource = getRequestSource(request, context)
+    const logGateEvent = (details: Record<string, unknown>) =>
+      logFormSpamEvent({
+        surface: 'forms-gate',
+        method: request.method,
+        path: pathname,
+        source: requestSource,
+        ...details,
+      })
+
     // Only gate POSTs to /forms/*; pass through everything else
     if (request.method !== 'POST') {
-      console.log('[forms-gate] non-POST, passing through')
+      logGateEvent({
+        action: 'forms-gate.bypass',
+        result: 'passed-through',
+        reason: 'non-post',
+      })
       return context.next()
     }
     // Defensive: ensure this only processes /forms/* paths even if mis-mapped
     if (!pathname.startsWith('/forms/')) {
-      console.log('[forms-gate] non-/forms path, passing through')
+      logGateEvent({
+        action: 'forms-gate.bypass',
+        result: 'passed-through',
+        reason: 'non-form-path',
+      })
       return context.next()
     }
 
-    const requestSource = getRequestSource(request, context)
     const rateLimitResult = checkRateLimit({
       policy: RATE_LIMIT_POLICIES.formsSubmit,
       source: requestSource,
@@ -137,7 +153,12 @@ export default async (request: Request, context: any) => {
     try {
       formData = await parseReq.formData()
     } catch (_e) {
-      console.log('[forms-gate] invalid form data')
+      logGateEvent({
+        action: 'forms-gate.validation',
+        result: 'failed',
+        reason: 'validation-error',
+        status: 400,
+      })
       return new Response(
         JSON.stringify({ ok: false, error: 'Invalid form data' }),
         {
@@ -150,9 +171,14 @@ export default async (request: Request, context: any) => {
     // Honeypot check
     const honey = formData.get('additional-info')
     if (typeof honey === 'string' && honey.trim().length > 0) {
-      console.log('[forms-gate] honeypot triggered')
       // Silently accept to not tip off bots, but do not forward to Forms
       const accept = request.headers.get('accept') || ''
+      logGateEvent({
+        action: 'forms-gate.submission',
+        result: 'blocked',
+        reason: 'honeypot',
+        status: accept.includes('application/json') ? 200 : 303,
+      })
       if (accept.includes('application/json')) {
         return new Response(JSON.stringify({ ok: true, skipped: true }), {
           status: 200,
@@ -173,7 +199,12 @@ export default async (request: Request, context: any) => {
     const capToken = formData.get('cap-token')
 
     if (!formName || (typeof formName === 'string' && formName.trim() === '')) {
-      console.log('[forms-gate] missing form-name')
+      logGateEvent({
+        action: 'forms-gate.validation',
+        result: 'failed',
+        reason: 'validation-error',
+        status: 422,
+      })
       return new Response(
         JSON.stringify({ ok: false, error: 'Missing form-name' }),
         {
@@ -187,8 +218,13 @@ export default async (request: Request, context: any) => {
     }
 
     if (!capToken || (typeof capToken === 'string' && capToken.trim() === '')) {
-      console.log('[forms-gate] missing cap-token')
       const accept = request.headers.get('accept') || ''
+      logGateEvent({
+        action: 'forms-gate.submission',
+        result: 'blocked',
+        reason: 'missing-token',
+        status: accept.includes('application/json') ? 422 : 303,
+      })
       if (accept.includes('application/json')) {
         return new Response(
           JSON.stringify({ ok: false, error: 'Missing cap-token' }),
@@ -234,21 +270,35 @@ export default async (request: Request, context: any) => {
       })
 
       if (!res.ok) {
-        console.log(
-          `[forms-gate] cap validate unavailable status=${res.status}`,
-        )
+        logGateEvent({
+          action: 'forms-gate.validation',
+          result: 'failed',
+          reason: 'upstream-forwarding',
+          status: 503,
+          upstreamStatus: res.status,
+        })
         return capUnavailableResponse()
       }
 
       const data = await res.json()
       valid = Boolean(data && data.success)
-      console.log(`[forms-gate] cap validate success=${valid}`)
     } catch (_e) {
-      console.log('[forms-gate] cap validate unavailable')
+      logGateEvent({
+        action: 'forms-gate.validation',
+        result: 'failed',
+        reason: 'upstream-forwarding',
+        status: 503,
+      })
       return capUnavailableResponse()
     }
 
     if (!valid) {
+      logGateEvent({
+        action: 'forms-gate.submission',
+        result: 'blocked',
+        reason: 'invalid-token',
+        status: 422,
+      })
       return new Response(
         JSON.stringify({ ok: false, error: 'Invalid cap-token' }),
         {
@@ -266,10 +316,14 @@ export default async (request: Request, context: any) => {
     let upstream: Response | undefined
     try {
       upstream = await context.next(forwardReq)
-      console.log('[forms-gate] forwarded to forms')
     } catch (_e) {
       // If forwarding fails, return an error to client
-      console.log('[forms-gate] forward failed')
+      logGateEvent({
+        action: 'forms-gate.forward',
+        result: 'failed',
+        reason: 'upstream-forwarding',
+        status: 502,
+      })
       return new Response(
         JSON.stringify({ ok: false, error: 'Forward failed' }),
         {
@@ -288,6 +342,13 @@ export default async (request: Request, context: any) => {
     const upstreamOk = upstreamStatus < 400
     if (accept.includes('application/json')) {
       if (upstreamOk) {
+        logGateEvent({
+          action: 'forms-gate.forward',
+          result: 'forwarded',
+          reason: 'forwarded',
+          status: 200,
+          upstreamStatus,
+        })
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: {
@@ -297,6 +358,13 @@ export default async (request: Request, context: any) => {
           },
         })
       }
+      logGateEvent({
+        action: 'forms-gate.forward',
+        result: 'failed',
+        reason: 'upstream-forwarding',
+        status: 502,
+        upstreamStatus,
+      })
       return new Response(
         JSON.stringify({
           ok: false,
@@ -315,6 +383,13 @@ export default async (request: Request, context: any) => {
     }
 
     if (upstreamOk) {
+      logGateEvent({
+        action: 'forms-gate.forward',
+        result: 'forwarded',
+        reason: 'forwarded',
+        status: 303,
+        upstreamStatus,
+      })
       return new Response(null, {
         status: 303,
         headers: {
@@ -325,12 +400,27 @@ export default async (request: Request, context: any) => {
       })
     }
     // On non-XHR and upstream error, surface upstream response to client
+    logGateEvent({
+      action: 'forms-gate.forward',
+      result: 'failed',
+      reason: 'upstream-forwarding',
+      status: upstreamStatus,
+      upstreamStatus,
+    })
     return upstream as Response
   } catch (err) {
-    console.log(
-      '[forms-gate] unhandled error',
-      (err as any)?.message || String(err),
-    )
+    const { pathname } = new URL(request.url)
+    logFormSpamEvent({
+      surface: 'forms-gate',
+      action: 'forms-gate.validation',
+      result: 'failed',
+      reason: 'validation-error',
+      method: request.method,
+      path: pathname,
+      source: getRequestSource(request, context),
+      status: 500,
+      errorType: (err as any)?.name || 'Error',
+    })
     return new Response(JSON.stringify({ ok: false, error: 'Edge crash' }), {
       status: 500,
       headers: { 'content-type': 'application/json', 'x-forms-gate': 'crash' },

--- a/astro/netlify/edge-functions/forms-gate.ts
+++ b/astro/netlify/edge-functions/forms-gate.ts
@@ -412,9 +412,9 @@ export default async (request: Request, context: any) => {
     const { pathname } = new URL(request.url)
     logFormSpamEvent({
       surface: 'forms-gate',
-      action: 'forms-gate.validation',
+      action: 'forms-gate.request',
       result: 'failed',
-      reason: 'validation-error',
+      reason: 'operational-error',
       method: request.method,
       path: pathname,
       source: getRequestSource(request, context),

--- a/astro/netlify/functions/_shared/cap.test.js
+++ b/astro/netlify/functions/_shared/cap.test.js
@@ -8,9 +8,10 @@ import { RATE_LIMIT_POLICIES } from './rate-limit.js'
 const originalNetlify = globalThis.Netlify
 const TEST_CAP_SECRET = 'test-cap-token-secret-value-12345'
 
-test('CapJS handler completes the stateless challenge flow once', async () => {
+test('CapJS handler completes the stateless challenge flow once', async (t) => {
   const originalTokenStore = globalThis.__loumarcCapTokenStore
   const store = createMemoryTokenStore()
+  const logs = captureFormSpamLogs(t)
   globalThis.__loumarcCapTokenStore = store
   globalThis.Netlify = {
     env: {
@@ -83,6 +84,23 @@ test('CapJS handler completes the stateless challenge flow once', async () => {
     assert.deepEqual(await validateResponse.json(), { success: true })
     assert.equal(replayResponse.status, 200)
     assert.deepEqual(await replayResponse.json(), { success: false })
+
+    const capReasons = logs
+      .filter((log) => log.surface === 'cap-verification')
+      .map((log) => log.reason)
+    assert.equal(capReasons.includes('challenge-created'), true)
+    assert.equal(capReasons.includes('redeem-success'), true)
+    assert.equal(capReasons.includes('validate-success'), true)
+    assert.equal(capReasons.includes('validate-failure'), true)
+    assert.equal(
+      logs.some(
+        (log) =>
+          Object.hasOwn(log, 'token') ||
+          Object.hasOwn(log, 'solutions') ||
+          Object.hasOwn(log, 'source'),
+      ),
+      false,
+    )
   } finally {
     globalThis.Netlify = originalNetlify
     if (originalTokenStore === undefined) {
@@ -93,7 +111,8 @@ test('CapJS handler completes the stateless challenge flow once', async () => {
   }
 })
 
-test('CapJS validate returns a normal validation error before rate limiting', async () => {
+test('CapJS validate returns a normal validation error before rate limiting', async (t) => {
+  const logs = captureFormSpamLogs(t)
   const response = await capHandler(
     new Request('https://loumarcsigns.com/.netlify/functions/cap/validate', {
       method: 'POST',
@@ -108,6 +127,17 @@ test('CapJS validate returns a normal validation error before rate limiting', as
 
   assert.equal(response.status, 400)
   assert.deepEqual(await response.json(), { success: false })
+  assert.equal(
+    logs.some(
+      (log) =>
+        log.surface === 'cap-verification' &&
+        log.action === 'cap.validate' &&
+        log.reason === 'malformed-request' &&
+        log.result === 'malformed' &&
+        log.status === 400,
+    ),
+    true,
+  )
 })
 
 test('CapJS endpoints return 429 after repeated same-source traffic', async (t) => {
@@ -218,6 +248,21 @@ function prng(seed, length) {
   }
 
   return result.substring(0, length)
+}
+
+function captureFormSpamLogs(t) {
+  const logs = []
+
+  t.mock.method(console, 'log', (line) => {
+    try {
+      const parsed = JSON.parse(line)
+      if (parsed.event === 'loumarc.form_spam') {
+        logs.push(parsed)
+      }
+    } catch (_error) {}
+  })
+
+  return logs
 }
 
 test('CapJS validate trusts the internal source header for fallback limiting', async () => {

--- a/astro/netlify/functions/_shared/cap.test.js
+++ b/astro/netlify/functions/_shared/cap.test.js
@@ -4,6 +4,7 @@ import { test } from 'node:test'
 
 import capHandler from '../cap.js'
 import { RATE_LIMIT_POLICIES } from './rate-limit.js'
+import { createChallenge } from './stateless-cap.js'
 
 const originalNetlify = globalThis.Netlify
 const TEST_CAP_SECRET = 'test-cap-token-secret-value-12345'
@@ -175,6 +176,178 @@ test('CapJS endpoints return 429 after repeated same-source traffic', async (t) 
     error: 'Too many requests',
     retryAfter: 60,
   })
+})
+
+test('CapJS malformed direct requests are rate limited before malformed logs repeat', async (t) => {
+  const originalLimit = RATE_LIMIT_POLICIES.capValidate.max
+  const logs = captureFormSpamLogs(t)
+  RATE_LIMIT_POLICIES.capValidate.max = 1
+
+  try {
+    const firstResponse = await capHandler(
+      new Request('https://loumarcsigns.com/.netlify/functions/cap/validate', {
+        headers: {
+          'x-forwarded-for': '203.0.113.44',
+        },
+        method: 'GET',
+      }),
+      {},
+    )
+    const secondResponse = await capHandler(
+      new Request('https://loumarcsigns.com/.netlify/functions/cap/validate', {
+        headers: {
+          'x-forwarded-for': '203.0.113.44',
+        },
+        method: 'GET',
+      }),
+      {},
+    )
+
+    assert.equal(firstResponse.status, 405)
+    assert.equal(secondResponse.status, 429)
+    assert.equal(
+      logs.filter(
+        (log) =>
+          log.surface === 'cap-verification' &&
+          log.action === 'cap.request' &&
+          log.reason === 'malformed-request',
+      ).length,
+      1,
+    )
+  } finally {
+    RATE_LIMIT_POLICIES.capValidate.max = originalLimit
+  }
+})
+
+test('CapJS malformed paths use an allow-listed monitoring path', async (t) => {
+  const logs = captureFormSpamLogs(t)
+  const response = await capHandler(
+    new Request(
+      'https://loumarcsigns.com/.netlify/functions/cap/validate/lc_cap_secret_customer@example.com',
+      {
+        headers: {
+          'x-forwarded-for': '203.0.113.45',
+        },
+        method: 'POST',
+      },
+    ),
+    {},
+  )
+
+  assert.equal(response.status, 404)
+  assert.equal(
+    logs.some(
+      (log) =>
+        log.surface === 'cap-verification' &&
+        log.action === 'cap.request' &&
+        log.reason === 'malformed-request' &&
+        log.path === '/.netlify/functions/cap/unknown',
+    ),
+    true,
+  )
+  assert.equal(JSON.stringify(logs).includes('lc_cap_secret'), false)
+  assert.equal(JSON.stringify(logs).includes('customer@example.com'), false)
+})
+
+test('CapJS operational failures use structured monitoring events', async (t) => {
+  const originalTokenStore = globalThis.__loumarcCapTokenStore
+  const logs = captureFormSpamLogs(t)
+  t.mock.method(console, 'error', () => {})
+  globalThis.Netlify = {
+    env: {
+      get() {
+        return undefined
+      },
+    },
+  }
+
+  try {
+    const configResponse = await capHandler(
+      new Request('https://loumarcsigns.com/api/challenge', {
+        headers: {
+          'x-forwarded-for': '203.0.113.46',
+        },
+        method: 'POST',
+      }),
+      {},
+    )
+
+    globalThis.Netlify = {
+      env: {
+        get(name) {
+          return name === 'LOUMARC_CAP_TOKEN_SECRET'
+            ? TEST_CAP_SECRET
+            : undefined
+        },
+      },
+    }
+    globalThis.__loumarcCapTokenStore = {
+      async set() {
+        throw new Error('store unavailable')
+      },
+    }
+    const challenge = createChallenge({
+      challengeCount: 1,
+      challengeDifficulty: 0,
+      challengeSize: 8,
+      secret: TEST_CAP_SECRET,
+    })
+    const storeResponse = await capHandler(
+      new Request('https://loumarcsigns.com/api/redeem', {
+        body: JSON.stringify({
+          solutions: solveChallenge(challenge),
+          token: challenge.token,
+        }),
+        headers: {
+          'content-type': 'application/json',
+          'x-forwarded-for': '203.0.113.47',
+        },
+        method: 'POST',
+      }),
+      {},
+    )
+
+    assert.equal(configResponse.status, 500)
+    assert.equal(storeResponse.status, 503)
+    assert.equal(
+      logs.some(
+        (log) =>
+          log.action === 'cap.challenge' &&
+          log.reason === 'operational-error' &&
+          log.result === 'failed' &&
+          log.status === 500 &&
+          log.errorType === 'CapConfigurationError',
+      ),
+      true,
+    )
+    assert.equal(
+      logs.some(
+        (log) =>
+          log.action === 'cap.redeem' &&
+          log.reason === 'operational-error' &&
+          log.result === 'failed' &&
+          log.status === 503 &&
+          log.errorType === 'CapStoreError',
+      ),
+      true,
+    )
+    assert.equal(
+      logs.some(
+        (log) =>
+          Object.hasOwn(log, 'token') ||
+          Object.hasOwn(log, 'solutions') ||
+          Object.hasOwn(log, 'source'),
+      ),
+      false,
+    )
+  } finally {
+    globalThis.Netlify = originalNetlify
+    if (originalTokenStore === undefined) {
+      delete globalThis.__loumarcCapTokenStore
+    } else {
+      globalThis.__loumarcCapTokenStore = originalTokenStore
+    }
+  }
 })
 
 function createMemoryTokenStore() {

--- a/astro/netlify/functions/_shared/forms-gate.test.js
+++ b/astro/netlify/functions/_shared/forms-gate.test.js
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import formsGate from '../../edge-functions/forms-gate.ts'
+
+test('forms gate logs honeypot, missing token, invalid token, and forwarded outcomes', async (t) => {
+  const logs = captureFormSpamLogs(t)
+  let capSuccess = false
+
+  t.mock.method(globalThis, 'fetch', async () =>
+    jsonResponse({ success: capSuccess }),
+  )
+
+  const honeypot = await formsGate(
+    formRequest({
+      accept: 'application/json',
+      body: {
+        'additional-info': 'filled',
+        'cap-token': 'not-used',
+        'form-name': 'contact',
+      },
+      source: '203.0.113.80',
+    }),
+    { next: async () => new Response(null, { status: 204 }) },
+  )
+  const missingToken = await formsGate(
+    formRequest({
+      accept: 'application/json',
+      body: { 'form-name': 'contact' },
+      source: '203.0.113.81',
+    }),
+    { next: async () => new Response(null, { status: 204 }) },
+  )
+  const invalidToken = await formsGate(
+    formRequest({
+      accept: 'application/json',
+      body: { 'cap-token': 'invalid-token', 'form-name': 'contact' },
+      source: '203.0.113.82',
+    }),
+    { next: async () => new Response(null, { status: 204 }) },
+  )
+
+  capSuccess = true
+  const forwarded = await formsGate(
+    formRequest({
+      accept: 'application/json',
+      body: { 'cap-token': 'valid-token', 'form-name': 'contact' },
+      source: '203.0.113.83',
+    }),
+    { next: async () => new Response(null, { status: 202 }) },
+  )
+
+  assert.equal(honeypot.status, 200)
+  assert.equal(missingToken.status, 422)
+  assert.equal(invalidToken.status, 422)
+  assert.equal(forwarded.status, 200)
+  assert.deepEqual(
+    logs
+      .filter((log) => log.surface === 'forms-gate')
+      .map(({ action, reason, result, status, upstreamStatus }) => ({
+        action,
+        reason,
+        result,
+        status,
+        upstreamStatus,
+      })),
+    [
+      {
+        action: 'forms-gate.submission',
+        reason: 'honeypot',
+        result: 'blocked',
+        status: 200,
+        upstreamStatus: undefined,
+      },
+      {
+        action: 'forms-gate.submission',
+        reason: 'missing-token',
+        result: 'blocked',
+        status: 422,
+        upstreamStatus: undefined,
+      },
+      {
+        action: 'forms-gate.submission',
+        reason: 'invalid-token',
+        result: 'blocked',
+        status: 422,
+        upstreamStatus: undefined,
+      },
+      {
+        action: 'forms-gate.forward',
+        reason: 'forwarded',
+        result: 'forwarded',
+        status: 200,
+        upstreamStatus: 202,
+      },
+    ],
+  )
+  assertNoSensitiveLogFields(logs)
+})
+
+test('forms gate logs upstream and operational failures distinctly', async (t) => {
+  const logs = captureFormSpamLogs(t)
+
+  t.mock.method(
+    globalThis,
+    'fetch',
+    async () =>
+      new Response(JSON.stringify({ success: false }), { status: 503 }),
+  )
+  const validationUnavailable = await formsGate(
+    formRequest({
+      accept: 'application/json',
+      body: { 'cap-token': 'token', 'form-name': 'contact' },
+      source: '203.0.113.84',
+    }),
+    { next: async () => new Response(null, { status: 204 }) },
+  )
+
+  const crashed = await formsGate(
+    {
+      arrayBuffer() {
+        throw new Error('body unavailable')
+      },
+      headers: new Headers({
+        accept: 'application/json',
+        'x-forwarded-for': '203.0.113.85',
+      }),
+      method: 'POST',
+      url: 'https://loumarcsigns.com/forms/contact?email=private@example.com',
+    },
+    {},
+  )
+
+  assert.equal(validationUnavailable.status, 503)
+  assert.equal(crashed.status, 500)
+  assert.equal(
+    logs.some(
+      (log) =>
+        log.action === 'forms-gate.validation' &&
+        log.reason === 'upstream-forwarding' &&
+        log.result === 'failed' &&
+        log.status === 503 &&
+        log.upstreamStatus === 503,
+    ),
+    true,
+  )
+  assert.equal(
+    logs.some(
+      (log) =>
+        log.action === 'forms-gate.request' &&
+        log.reason === 'operational-error' &&
+        log.result === 'failed' &&
+        log.status === 500,
+    ),
+    true,
+  )
+  assert.equal(
+    logs.some((log) => log.path.includes('private@example.com')),
+    false,
+  )
+  assertNoSensitiveLogFields(logs)
+})
+
+function formRequest({ accept, body, source }) {
+  return new Request('https://loumarcsigns.com/forms/contact', {
+    body: new URLSearchParams(body),
+    headers: {
+      accept,
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-forwarded-for': source,
+    },
+    method: 'POST',
+  })
+}
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function captureFormSpamLogs(t) {
+  const logs = []
+
+  t.mock.method(console, 'log', (line) => {
+    try {
+      const parsed = JSON.parse(line)
+      if (parsed.event === 'loumarc.form_spam') {
+        logs.push(parsed)
+      }
+    } catch (_error) {}
+  })
+
+  return logs
+}
+
+function assertNoSensitiveLogFields(logs) {
+  assert.equal(
+    logs.some(
+      (log) =>
+        Object.hasOwn(log, 'token') ||
+        Object.hasOwn(log, 'source') ||
+        Object.hasOwn(log, 'email'),
+    ),
+    false,
+  )
+}

--- a/astro/netlify/functions/_shared/rate-limit.js
+++ b/astro/netlify/functions/_shared/rate-limit.js
@@ -1,3 +1,5 @@
+import { fingerprintSource, logFormSpamEvent } from './spam-monitoring.js'
+
 const DEFAULT_STORE = new Map()
 const MAX_STORE_SIZE = 10000
 
@@ -112,9 +114,22 @@ export function createRateLimitResponse(result) {
 
 export function logRateLimitDecision(result, { method, path }) {
   const decision = result.allowed ? 'allowed' : 'blocked'
-  console.log(
-    `[rate-limit] ${decision} policy=${result.policy} method=${method} path=${path} source=${result.sourceHash} count=${result.count}/${result.limit} reset=${new Date(result.resetAt).toISOString()}`,
-  )
+  logFormSpamEvent({
+    surface: 'rate-limit',
+    action: 'rate-limit.decision',
+    result: decision,
+    reason: result.allowed ? 'under-limit' : 'rate-limit',
+    method,
+    path,
+    sourceHash: result.sourceHash,
+    rateLimitPolicy: result.policy,
+    rateLimitCount: result.count,
+    rateLimitLimit: result.limit,
+    rateLimitReset: new Date(result.resetAt).toISOString(),
+    rateLimitWindowSeconds: result.windowSeconds,
+    retryAfterSeconds: result.allowed ? undefined : result.retryAfterSeconds,
+    status: result.allowed ? undefined : 429,
+  })
 }
 
 export function rateLimitHeaders(result) {
@@ -146,14 +161,4 @@ function evictOverflowBuckets(store) {
     if (store.size <= MAX_STORE_SIZE) return
     store.delete(key)
   }
-}
-
-function fingerprintSource(source) {
-  let hash = 5381
-
-  for (let index = 0; index < source.length; index += 1) {
-    hash = (hash * 33) ^ source.charCodeAt(index)
-  }
-
-  return (hash >>> 0).toString(16).padStart(8, '0')
 }

--- a/astro/netlify/functions/_shared/rate-limit.js
+++ b/astro/netlify/functions/_shared/rate-limit.js
@@ -26,6 +26,11 @@ export const RATE_LIMIT_POLICIES = {
     windowMs: 60 * 1000,
     max: 30,
   },
+  capMalformed: {
+    name: 'cap-malformed',
+    windowMs: 60 * 1000,
+    max: 10,
+  },
 }
 
 export function getRequestSource(request, context, options = {}) {

--- a/astro/netlify/functions/_shared/rate-limit.test.js
+++ b/astro/netlify/functions/_shared/rate-limit.test.js
@@ -5,6 +5,7 @@ import {
   checkRateLimit,
   createRateLimitResponse,
   getRequestSource,
+  logRateLimitDecision,
   RATE_LIMIT_POLICIES,
 } from './rate-limit.js'
 
@@ -152,5 +153,46 @@ test('blocked responses use 429 and expose retry headers', async () => {
     ok: false,
     error: 'Too many requests',
     retryAfter: 58,
+  })
+})
+
+test('rate-limit decisions use the shared form-spam log shape', (t) => {
+  const logLines = []
+  t.mock.method(console, 'log', (line) => {
+    logLines.push(JSON.parse(line))
+  })
+
+  logRateLimitDecision(
+    {
+      allowed: false,
+      count: 3,
+      limit: 2,
+      policy: 'test-policy',
+      remaining: 0,
+      resetAt: 61000,
+      retryAfterSeconds: 58,
+      sourceHash: '00000000',
+      windowSeconds: 60,
+    },
+    { method: 'POST', path: '/forms/contact?ignored=true' },
+  )
+
+  assert.deepEqual(logLines[0], {
+    event: 'loumarc.form_spam',
+    schemaVersion: 1,
+    surface: 'rate-limit',
+    action: 'rate-limit.decision',
+    result: 'blocked',
+    reason: 'rate-limit',
+    method: 'POST',
+    path: '/forms/contact',
+    status: 429,
+    sourceHash: '00000000',
+    rateLimitPolicy: 'test-policy',
+    rateLimitCount: 3,
+    rateLimitLimit: 2,
+    rateLimitReset: '1970-01-01T00:01:01.000Z',
+    rateLimitWindowSeconds: 60,
+    retryAfterSeconds: 58,
   })
 })

--- a/astro/netlify/functions/_shared/spam-monitoring.js
+++ b/astro/netlify/functions/_shared/spam-monitoring.js
@@ -1,0 +1,93 @@
+const FORM_SPAM_EVENT = 'loumarc.form_spam'
+const SCHEMA_VERSION = 1
+
+const OPTIONAL_FIELDS = [
+  'method',
+  'path',
+  'status',
+  'upstreamStatus',
+  'rateLimitPolicy',
+  'rateLimitCount',
+  'rateLimitLimit',
+  'rateLimitReset',
+  'rateLimitWindowSeconds',
+  'retryAfterSeconds',
+  'errorType',
+]
+
+export function buildFormSpamLogEntry({
+  surface,
+  action,
+  result,
+  reason,
+  method,
+  path,
+  source,
+  sourceHash,
+  status,
+  upstreamStatus,
+  rateLimitPolicy,
+  rateLimitCount,
+  rateLimitLimit,
+  rateLimitReset,
+  rateLimitWindowSeconds,
+  retryAfterSeconds,
+  errorType,
+}) {
+  const entry = {
+    event: FORM_SPAM_EVENT,
+    schemaVersion: SCHEMA_VERSION,
+    surface,
+    action,
+    result,
+    reason,
+  }
+
+  const values = {
+    method,
+    path: sanitizePath(path),
+    status,
+    upstreamStatus,
+    sourceHash: sourceHash || fingerprintSource(source || 'unknown'),
+    rateLimitPolicy,
+    rateLimitCount,
+    rateLimitLimit,
+    rateLimitReset,
+    rateLimitWindowSeconds,
+    retryAfterSeconds,
+    errorType,
+  }
+
+  for (const field of ['sourceHash', ...OPTIONAL_FIELDS]) {
+    if (values[field] !== undefined && values[field] !== '') {
+      entry[field] = values[field]
+    }
+  }
+
+  return entry
+}
+
+export function logFormSpamEvent(details) {
+  console.log(JSON.stringify(buildFormSpamLogEntry(details)))
+}
+
+export function fingerprintSource(source) {
+  let hash = 5381
+  const value = String(source || 'unknown')
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index)
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function sanitizePath(path) {
+  if (!path) return undefined
+
+  try {
+    return new URL(path, 'https://loumarcsigns.com').pathname
+  } catch (_error) {
+    return String(path).split('?')[0]
+  }
+}

--- a/astro/netlify/functions/_shared/spam-monitoring.test.js
+++ b/astro/netlify/functions/_shared/spam-monitoring.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { buildFormSpamLogEntry, fingerprintSource } from './spam-monitoring.js'
+
+test('form spam log entries use the shared low-PII shape', () => {
+  const entry = buildFormSpamLogEntry({
+    surface: 'forms-gate',
+    action: 'forms-gate.submission',
+    result: 'blocked',
+    reason: 'missing-token',
+    method: 'POST',
+    path: '/forms/contact?email=customer@example.com',
+    source: '203.0.113.10',
+    status: 422,
+    token: 'lc_cap_secret',
+    email: 'customer@example.com',
+  })
+
+  assert.deepEqual(entry, {
+    event: 'loumarc.form_spam',
+    schemaVersion: 1,
+    surface: 'forms-gate',
+    action: 'forms-gate.submission',
+    result: 'blocked',
+    reason: 'missing-token',
+    method: 'POST',
+    path: '/forms/contact',
+    status: 422,
+    sourceHash: fingerprintSource('203.0.113.10'),
+  })
+  assert.equal('source' in entry, false)
+  assert.equal('token' in entry, false)
+  assert.equal('email' in entry, false)
+})

--- a/astro/netlify/functions/cap.js
+++ b/astro/netlify/functions/cap.js
@@ -21,6 +21,7 @@ import {
   logRateLimitDecision,
   RATE_LIMIT_POLICIES,
 } from './_shared/rate-limit.js'
+import { logFormSpamEvent } from './_shared/spam-monitoring.js'
 import {
   CapConfigurationError,
   CapStoreError,
@@ -35,20 +36,50 @@ const INTERNAL_SECRET_HEADER = 'x-loumarc-internal-secret'
 export default async function handler(request, context) {
   const { pathname } = new URL(request.url)
   const route = pathname.replace(/\/$/, '')
+  const requestSource = getRequestSource(request, context)
+  const logRequestEvent = (details) =>
+    logFormSpamEvent({
+      surface: 'cap-verification',
+      method: request.method,
+      path: pathname,
+      source: requestSource,
+      ...details,
+    })
 
   if (request.method !== 'POST') {
+    logRequestEvent({
+      action: 'cap.request',
+      result: 'malformed',
+      reason: 'malformed-request',
+      status: 405,
+    })
     return new Response(null, { status: 405 })
   }
 
   const policy = policyForRoute(route)
 
   if (!policy) {
+    logRequestEvent({
+      action: 'cap.request',
+      result: 'malformed',
+      reason: 'malformed-request',
+      status: 404,
+    })
     return new Response(null, { status: 404 })
   }
 
+  const rateLimitSource = getRateLimitSource({ context, request, route })
+  const logCapEvent = (details) =>
+    logFormSpamEvent({
+      surface: 'cap-verification',
+      method: request.method,
+      path: pathname,
+      source: rateLimitSource,
+      ...details,
+    })
   const rateLimitResult = checkRateLimit({
     policy,
-    source: getRateLimitSource({ context, request, route }),
+    source: rateLimitSource,
   })
   logRateLimitDecision(rateLimitResult, {
     method: request.method,
@@ -61,41 +92,81 @@ export default async function handler(request, context) {
 
   if (route.endsWith('/challenge')) {
     try {
-      return jsonResponse(createChallenge())
+      const challenge = createChallenge()
+      logCapEvent({
+        action: 'cap.challenge',
+        result: 'created',
+        reason: 'challenge-created',
+        status: 200,
+      })
+      return jsonResponse(challenge)
     } catch (error) {
-      return capErrorResponse(error)
+      return capErrorResponse(error, {
+        action: 'cap.challenge',
+        logCapEvent,
+      })
     }
   }
 
   if (route.endsWith('/redeem')) {
-    const body = await readJson(request)
+    const { body, malformedJson } = await readJson(request)
     const { token, solutions } = body
 
-    if (!token || !solutions) {
+    if (malformedJson || !token || !solutions) {
+      logCapEvent({
+        action: 'cap.redeem',
+        result: 'malformed',
+        reason: 'malformed-request',
+        status: 400,
+      })
       return jsonResponse({ success: false }, { status: 400 })
     }
 
     try {
       const result = await redeemChallenge({ token, solutions })
+      logCapEvent({
+        action: 'cap.redeem',
+        result: result.success ? 'success' : 'failure',
+        reason: result.success ? 'redeem-success' : 'redeem-failure',
+        status: 200,
+      })
       return jsonResponse(result)
     } catch (error) {
-      return capErrorResponse(error)
+      return capErrorResponse(error, {
+        action: 'cap.redeem',
+        logCapEvent,
+      })
     }
   }
 
   if (route.endsWith('/validate')) {
-    const body = await readJson(request)
+    const { body, malformedJson } = await readJson(request)
     const { token } = body
 
-    if (!token) {
+    if (malformedJson || !token) {
+      logCapEvent({
+        action: 'cap.validate',
+        result: 'malformed',
+        reason: 'malformed-request',
+        status: 400,
+      })
       return jsonResponse({ success: false }, { status: 400 })
     }
 
     try {
       const result = await validateToken({ token })
+      logCapEvent({
+        action: 'cap.validate',
+        result: result.success ? 'success' : 'failure',
+        reason: result.success ? 'validate-success' : 'validate-failure',
+        status: 200,
+      })
       return jsonResponse(result)
     } catch (error) {
-      return capErrorResponse(error)
+      return capErrorResponse(error, {
+        action: 'cap.validate',
+        logCapEvent,
+      })
     }
   }
 }
@@ -131,9 +202,9 @@ function getInternalSecret() {
 
 async function readJson(request) {
   try {
-    return await request.json()
+    return { body: await request.json(), malformedJson: false }
   } catch (_error) {
-    return {}
+    return { body: {}, malformedJson: true }
   }
 }
 
@@ -144,17 +215,40 @@ function jsonResponse(body, init = {}) {
   })
 }
 
-function capErrorResponse(error) {
+function capErrorResponse(error, { action, logCapEvent }) {
+  const errorType = error?.name || 'Error'
+
   if (error instanceof CapConfigurationError) {
     console.error('[cap] configuration error:', error.message)
+    logCapEvent({
+      action,
+      result: 'failed',
+      reason: 'operational-error',
+      status: 500,
+      errorType,
+    })
     return jsonResponse({ success: false }, { status: 500 })
   }
 
   if (error instanceof CapStoreError) {
     console.error('[cap] token store error:', error.message)
+    logCapEvent({
+      action,
+      result: 'failed',
+      reason: 'operational-error',
+      status: 503,
+      errorType,
+    })
     return jsonResponse({ success: false }, { status: 503 })
   }
 
   console.error('[cap] unexpected error:', error?.message || String(error))
+  logCapEvent({
+    action,
+    result: 'failed',
+    reason: 'operational-error',
+    status: 500,
+    errorType,
+  })
   return jsonResponse({ success: false }, { status: 500 })
 }

--- a/astro/netlify/functions/cap.js
+++ b/astro/netlify/functions/cap.js
@@ -32,22 +32,37 @@ import {
 
 const INTERNAL_SOURCE_HEADER = 'x-loumarc-client-source'
 const INTERNAL_SECRET_HEADER = 'x-loumarc-internal-secret'
+const UNKNOWN_CAP_ROUTE_PATH = '/.netlify/functions/cap/unknown'
 
 export default async function handler(request, context) {
   const { pathname } = new URL(request.url)
   const route = pathname.replace(/\/$/, '')
-  const requestSource = getRequestSource(request, context)
-  const logRequestEvent = (details) =>
+  const policy = policyForRoute(route)
+  const logPath = policy ? pathname : UNKNOWN_CAP_ROUTE_PATH
+  const rateLimitSource = getRateLimitSource({ context, request, route })
+  const logCapEvent = (details) =>
     logFormSpamEvent({
       surface: 'cap-verification',
       method: request.method,
-      path: pathname,
-      source: requestSource,
+      path: logPath,
+      source: rateLimitSource,
       ...details,
     })
+  const rateLimitResult = checkRateLimit({
+    policy: policy || RATE_LIMIT_POLICIES.capMalformed,
+    source: rateLimitSource,
+  })
+  logRateLimitDecision(rateLimitResult, {
+    method: request.method,
+    path: logPath,
+  })
+
+  if (!rateLimitResult.allowed) {
+    return createRateLimitResponse(rateLimitResult)
+  }
 
   if (request.method !== 'POST') {
-    logRequestEvent({
+    logCapEvent({
       action: 'cap.request',
       result: 'malformed',
       reason: 'malformed-request',
@@ -56,38 +71,14 @@ export default async function handler(request, context) {
     return new Response(null, { status: 405 })
   }
 
-  const policy = policyForRoute(route)
-
   if (!policy) {
-    logRequestEvent({
+    logCapEvent({
       action: 'cap.request',
       result: 'malformed',
       reason: 'malformed-request',
       status: 404,
     })
     return new Response(null, { status: 404 })
-  }
-
-  const rateLimitSource = getRateLimitSource({ context, request, route })
-  const logCapEvent = (details) =>
-    logFormSpamEvent({
-      surface: 'cap-verification',
-      method: request.method,
-      path: pathname,
-      source: rateLimitSource,
-      ...details,
-    })
-  const rateLimitResult = checkRateLimit({
-    policy,
-    source: rateLimitSource,
-  })
-  logRateLimitDecision(rateLimitResult, {
-    method: request.method,
-    path: pathname,
-  })
-
-  if (!rateLimitResult.allowed) {
-    return createRateLimitResponse(rateLimitResult)
   }
 
   if (route.endsWith('/challenge')) {

--- a/astro/package.json
+++ b/astro/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "astro check",
-    "test": "node --test \"netlify/functions/_shared/*.test.js\""
+    "test": "node --experimental-strip-types --test \"netlify/functions/_shared/*.test.js\""
   },
   "dependencies": {
     "@astrojs/netlify": "^7.0.1",


### PR DESCRIPTION
## Summary

Closes #43.

Adds structured, low-PII form-spam monitoring logs across the form gate, CapJS verification endpoints, and fallback rate-limit decisions.

## What changed

- Added a shared `loumarc.form_spam` JSON event schema with source fingerprinting and path sanitization.
- Instrumented `forms-gate.ts` for honeypot, missing-token, invalid-token, validation-error, forwarded, and upstream-forwarding outcomes.
- Instrumented CapJS challenge/redeem/validate endpoints for creation, success/failure, malformed requests, and operational failures.
- Reused the same event shape for fallback rate-limit decisions.
- Documented Netlify CLI commands for reviewing and counting recent form-spam activity.

## Validation

- `npm run test`
- `npm run lint`
- `npm run build`
