### PR TITLE
fix: restore Sanity-triggered production builds

### DIFF
--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -11,7 +11,7 @@
         "@astrojs/netlify": "^7.0.1",
         "@astrojs/partytown": "^2.1.5",
         "@astrojs/sitemap": "^3.7.1",
-        "@cap.js/widget": "^0.1.25",
+        "@cap.js/widget": "^0.1.56",
         "@netlify/blobs": "^10.7.1",
         "@portabletext/to-html": "^2.0.5",
         "@sanity/astro": "3.3.0",
@@ -3048,9 +3048,9 @@
       }
     },
     "node_modules/@cap.js/widget": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@cap.js/widget/-/widget-0.1.25.tgz",
-      "integrity": "sha512-OVKt1rOAzqgxuSk0j18K6KtLBwAarTn6g7kAsGXcW+DAYO++Xr32LY6sj8KS3C3gqZXkhozf50kVwmgQs7CzxA==",
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@cap.js/widget/-/widget-0.1.56.tgz",
+      "integrity": "sha512-j640dNNNIF8IWmwqmSx0ihgU8sz/6Jm9mHveeDWUk8aXVqFm+2TSsp5bawtMtgf0aa7rFkmT9p76jrqO1uSEpQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@capsizecss/unpack": {

--- a/astro/package.json
+++ b/astro/package.json
@@ -15,7 +15,7 @@
     "@astrojs/netlify": "^7.0.1",
     "@astrojs/partytown": "^2.1.5",
     "@astrojs/sitemap": "^3.7.1",
-    "@cap.js/widget": "^0.1.25",
+    "@cap.js/widget": "^0.1.56",
     "@netlify/blobs": "^10.7.1",
     "@portabletext/to-html": "^2.0.5",
     "@sanity/astro": "3.3.0",

--- a/astro/src/components/Head.astro
+++ b/astro/src/components/Head.astro
@@ -154,5 +154,5 @@ if (productSchema) {
 
     gtag('config', 'G-G4P6ZWLZZ5');
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/@cap.js/widget@0.1.25" async></script>
+  <script src="https://cdn.jsdelivr.net/npm/@cap.js/widget@0.1.56" async></script>
 </head>


### PR DESCRIPTION
Publishing new Sanity posts currently triggers Netlify builds that fail during dependency installation because Cap widget `0.1.25` has been removed from npm. Pinning both the build dependency and browser CDN script to the available `0.1.56` release restores clean cloud installs so static site rebuilds can include newly published content.

Validation:

- `npm --prefix astro ci`
- `npm run test` — 24 passing
- `npm run lint` — 0 errors; one existing Astro inline-script hint
- `npm run build` — successful, including the missing July blog route

No breaking changes or visual changes.
