### PR TITLE
fix: restore GA4 phone click delivery

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -15,12 +15,7 @@ export default defineConfig({
       useCdn: false,
     }),
     sitemap(),
-    partytown({
-      // Adds dataLayer.push as a forwarding-event.
-      config: {
-        forward: ['dataLayer.push'],
-      },
-    }),
+    partytown(),
   ],
 
   site: 'https://loumarcsigns.com',

--- a/astro/astro.config.test.js
+++ b/astro/astro.config.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('keeps the main-thread GA4 data layer off the Partytown bridge', async () => {
+  const config = await readFile(
+    new URL('./astro.config.mjs', import.meta.url),
+    'utf8',
+  )
+
+  assert.doesNotMatch(config, /forward:\s*\[[^\]]*['"]dataLayer\.push['"]/)
+})

--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.6.0",
       "dependencies": {
         "@astrojs/netlify": "^7.0.1",
-        "@astrojs/partytown": "^2.1.5",
+        "@astrojs/partytown": "^2.1.7",
         "@astrojs/sitemap": "^3.7.1",
         "@cap.js/widget": "^0.1.56",
         "@netlify/blobs": "^10.7.1",
@@ -1120,12 +1120,12 @@
       }
     },
     "node_modules/@astrojs/partytown": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.5.tgz",
-      "integrity": "sha512-Uo2Uqmvjh/5w08wGoVAspdj14hUoE28uQH8SkzaBMw9bTBNIviEkPi3VkJi+tj1ZYAY9oX7OSkRDJ48QRtMhlw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
+      "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
       "license": "MIT",
       "dependencies": {
-        "@qwik.dev/partytown": "^0.11.2",
+        "@qwik.dev/partytown": "^0.13.2",
         "mrmime": "^2.0.1"
       }
     },
@@ -8212,9 +8212,9 @@
       }
     },
     "node_modules/@qwik.dev/partytown": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.11.2.tgz",
-      "integrity": "sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
+      "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.7"

--- a/astro/package.json
+++ b/astro/package.json
@@ -9,11 +9,11 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "astro check",
-    "test": "node --experimental-strip-types --test \"netlify/functions/_shared/*.test.js\" \"src/**/*.test.js\""
+    "test": "node --experimental-strip-types --test \"astro.config.test.js\" \"netlify/functions/_shared/*.test.js\" \"src/**/*.test.js\""
   },
   "dependencies": {
     "@astrojs/netlify": "^7.0.1",
-    "@astrojs/partytown": "^2.1.5",
+    "@astrojs/partytown": "^2.1.7",
     "@astrojs/sitemap": "^3.7.1",
     "@cap.js/widget": "^0.1.56",
     "@netlify/blobs": "^10.7.1",

--- a/docs/partytown-research.md
+++ b/docs/partytown-research.md
@@ -1,0 +1,35 @@
+# Partytown integration research
+
+Checked 2026-08-10 against primary sources.
+
+## Summary
+
+Use `@astrojs/partytown` for the Hotjar bootstrap only. Keep both GA4 scripts on the main thread and do not configure `forward: ['dataLayer.push']`. Astro runs only scripts marked `type="text/partytown"` through Partytown; its docs say the browser Network panel should show Partytown intercepting such requests ([Astro integration guide](https://docs.astro.build/en/guides/integrations-guide/partytown/)).
+
+No Partytown or Hotjar sunset was found in their official documentation. Hotjar still documents the same tracking-code installation and verification flow ([Hotjar installation guide](https://help.hotjar.com/hc/en-us/articles/36819972345105-How-to-Install-Your-Hotjar-Tracking-Code), [Hotjar verification guide](https://help.hotjar.com/hc/en-us/articles/36819989669905-How-to-Check-That-Hotjar-Is-Working)).
+
+## Version information
+
+- Reviewed baseline: `@astrojs/partytown: ^2.1.5`; lockfile: `2.1.5`, with `@qwik.dev/partytown` `0.11.2`.
+- Current npm `latest`: `2.1.7` ([npm package](https://www.npmjs.com/package/@astrojs/partytown?activeTab=versions)).
+- Recommendation: update the declaration to `^2.1.7` and refresh the lockfile to `2.1.7`. The existing caret range can resolve it, but naming the current reviewed baseline makes installs and dependency review explicit. Version `2.1.6` fixes file-descriptor leaks when clients disconnect or reads fail. Version `2.1.7` updates `@qwik.dev/partytown` to `0.13.2` ([Astro changelog](https://github.com/withastro/astro/blob/main/packages/integrations/partytown/CHANGELOG.md#217)).
+- No breaking change is documented between `2.1.5` and `2.1.7`. The bundled Partytown changes are backward-compatible: `0.12.0` adds an opt-in `strictProxyHas` option; `0.13.0` is documentation-only; `0.13.1` removes deprecated-API Lighthouse warnings; `0.13.2` changes publishing metadata ([Partytown changelog](https://github.com/QwikDev/partytown/blob/main/CHANGELOG.md#0132)).
+
+## Key concepts
+
+`type="text/partytown"` selects worker execution. `forward` serves a different purpose: it patches a main-thread global and sends calls into the worker. Partytown recommends `forward: ['dataLayer.push']` only when Google Tag Manager or GA itself runs in Partytown ([Partytown GTM guide](https://partytown.qwik.dev/google-tag-manager/), [forwarding guide](https://partytown.qwik.dev/forwarding-events/)). Here GA4 remains ordinary JavaScript, so forwarding its main-thread `dataLayer.push` would cross an unwanted boundary and should stay absent.
+
+## Implementation and validation
+
+1. Build the production output with `npm run build`, then serve `dist/` with a static server for browser QA. The Netlify adapter does not support `astro preview`.
+2. Inspect the delivered HTML. Confirm the Hotjar bootstrap has `type="text/partytown"`. Confirm the external GA4 loader and inline `dataLayer`/`gtag` initializer do not have that type.
+3. Open a private browser window with blockers disabled. In DevTools Network, filter `partytown`; confirm Partytown library/worker requests load and the Hotjar script is intercepted. In Console, use Astro's default dev/preview debug mode or temporarily set `config.debug: true`; Partytown documents `logScriptExecution` for script execution details ([Astro debug configuration](https://docs.astro.build/en/guides/integrations-guide/partytown/#enabling-debug-mode), [Partytown debugging](https://partytown.qwik.dev/debugging/)).
+4. Filter Network by `hotjar`. Confirm requests include only site ID `3055288`, none are red, and the Hotjar dashboard reports **Installation successful** or **Collecting data**. Hotjar calls this Network check its most reliable manual verification ([Hotjar verification guide](https://help.hotjar.com/hc/en-us/articles/36819989669905-How-to-Check-That-Hotjar-Is-Working)).
+5. Filter Network by `gtag` or `google-analytics`. Confirm `gtag/js?id=G-G4P6ZWLZZ5` loads normally. In Console, confirm `typeof window.gtag === 'function'` and `Array.isArray(window.dataLayer)`. Trigger a telephone click and confirm its GA request/event while Hotjar continues to send requests.
+6. Keep the config assertion that rejects `dataLayer.push` in `forward`. This guards the intended execution split; browser QA proves behavior end to end.
+
+## Common issues
+
+- Blockers can suppress Hotjar and cause a false failure; disable them for verification.
+- No Hotjar requests means the tracking code did not execute. Red requests can indicate CSP or another network error. More than one Hotjar site ID means duplicate installation ([Hotjar verification guide](https://help.hotjar.com/hc/en-us/articles/36819989669905-How-to-Check-That-Hotjar-Is-Working)).
+- Do not infer worker execution from the Hotjar request alone. Check the script type plus Partytown debug/interception evidence.


### PR DESCRIPTION
## Summary

Telephone clicks can reach GA4 again. Partytown no longer intercepts the main-thread `dataLayer.push`, while Hotjar continues to run in its worker.

The Partytown integration is updated to 2.1.7. A config regression test prevents the GA4 queue from being forwarded again.

## Validation

- `npm test` — 28 passed
- `npm run lint` — 0 errors; one existing Cap widget hint
- `npm run build`
- Chrome — one `phone_click` queued from a telephone link; Partytown 0.13.2 ran Hotjar while GA4 stayed on the main thread

## Breaking changes

None.
